### PR TITLE
[Feature] Retry Mechanism and Error UI Added in Services Webview

### DIFF
--- a/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/ErrorScreen.kt
+++ b/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/ErrorScreen.kt
@@ -1,5 +1,6 @@
 package au.com.alfie.ecomm.designsystem.component.dialog
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +14,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import au.com.alfie.ecomm.designsystem.R
 import au.com.alfie.ecomm.designsystem.component.button.Button
 import au.com.alfie.ecomm.designsystem.component.button.ButtonType
@@ -21,10 +24,10 @@ import au.com.alfie.ecomm.designsystem.theme.Theme
 
 @Composable
 fun ErrorScreen(
-    message: String,
-    buttonLabel: String,
-    onClick: () -> Unit
+    data: ErrorData
 ) {
+    val context = LocalContext.current
+    val noButtonActionMessage = stringResource(R.string.error_screen_button_no_action_message)
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
@@ -37,7 +40,7 @@ fun ErrorScreen(
             )
             Spacer(modifier = Modifier.size(Theme.spacing.spacing16))
             Text(
-                text = message,
+                text = data.message,
                 style = Theme.typography.paragraphLarge
             )
             Spacer(modifier = Modifier.height(Theme.spacing.spacing20))
@@ -46,10 +49,22 @@ fun ErrorScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = Theme.spacing.spacing20),
-                onClick = onClick,
+                onClick = data.onButtonClick ?: {
+                    Toast.makeText(
+                        context,
+                        noButtonActionMessage,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                },
                 isEnabled = true,
-                text = buttonLabel
+                text = data.buttonLabel
             )
         }
     }
 }
+
+data class ErrorData(
+    val message: String,
+    val buttonLabel: String,
+    var onButtonClick: (() -> Unit)? = null
+)

--- a/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/ErrorScreen.kt
+++ b/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/ErrorScreen.kt
@@ -1,0 +1,55 @@
+package au.com.alfie.ecomm.designsystem.component.dialog
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import au.com.alfie.ecomm.designsystem.R
+import au.com.alfie.ecomm.designsystem.component.button.Button
+import au.com.alfie.ecomm.designsystem.component.button.ButtonType
+import au.com.alfie.ecomm.designsystem.theme.Theme
+
+@Composable
+fun ErrorScreen(
+    message: String,
+    buttonLabel: String,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                modifier = Modifier.size(Theme.iconSize.xLarge),
+                painter = painterResource(id = R.drawable.ic_informational_warning),
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.size(Theme.spacing.spacing16))
+            Text(
+                text = message,
+                style = Theme.typography.paragraphLarge
+            )
+            Spacer(modifier = Modifier.height(Theme.spacing.spacing20))
+            Button(
+                type = ButtonType.Primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Theme.spacing.spacing20),
+                onClick = onClick,
+                isEnabled = true,
+                text = buttonLabel
+            )
+        }
+    }
+}

--- a/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/error/ErrorScreen.kt
+++ b/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/error/ErrorScreen.kt
@@ -1,4 +1,4 @@
-package au.com.alfie.ecomm.designsystem.component.dialog
+package au.com.alfie.ecomm.designsystem.component.dialog.error
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
@@ -24,7 +24,7 @@ import au.com.alfie.ecomm.designsystem.theme.Theme
 
 @Composable
 fun ErrorScreen(
-    data: ErrorData
+    data: ErrorType
 ) {
     val context = LocalContext.current
     val noButtonActionMessage = stringResource(R.string.error_screen_button_no_action_message)
@@ -62,9 +62,3 @@ fun ErrorScreen(
         }
     }
 }
-
-data class ErrorData(
-    val message: String,
-    val buttonLabel: String,
-    var onButtonClick: (() -> Unit)? = null
-)

--- a/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/error/ErrorType.kt
+++ b/designsystem/src/main/java/au/com/alfie/ecomm/designsystem/component/dialog/error/ErrorType.kt
@@ -1,0 +1,7 @@
+package au.com.alfie.ecomm.designsystem.component.dialog.error
+
+data class ErrorType(
+    val message: String,
+    val buttonLabel: String,
+    var onButtonClick: (() -> Unit)? = null
+)

--- a/designsystem/src/main/res/values/strings.xml
+++ b/designsystem/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="gallery_controls_left_content_description">Previous media</string>
     <string name="gallery_controls_right_content_description">Next media</string>
     <string name="wishlist_screen_title">Wishlist</string>
+    <string name="error_screen_button_no_action_message">Action not specified</string>
 </resources>

--- a/feature/shop/src/main/java/au/com/alfie/ecomm/feature/shop/ShopScreen.kt
+++ b/feature/shop/src/main/java/au/com/alfie/ecomm/feature/shop/ShopScreen.kt
@@ -24,6 +24,7 @@ import au.com.alfie.ecomm.core.navigation.arguments.wishlist.wishlistNavArgs
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
 import au.com.alfie.ecomm.core.ui.test.SERVICES_PAGE
 import au.com.alfie.ecomm.designsystem.component.bottombar.BottomBarState
+import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
 import au.com.alfie.ecomm.designsystem.component.segmented.SegmentedItem
 import au.com.alfie.ecomm.designsystem.component.segmented.SegmentedPage
 import au.com.alfie.ecomm.designsystem.component.snackbar.SnackbarCustomHostState
@@ -137,7 +138,11 @@ private fun ShopScreenContent(
                 deeplinkHandler = deeplinkHandler,
                 onEvent = onWebViewEvent,
                 isBackHandlerEnabled = false,
-                modifier = Modifier.testTag(SERVICES_PAGE)
+                modifier = Modifier.testTag(SERVICES_PAGE),
+                errorData = ErrorData(
+                    message = stringResource(R.string.error_failed_to_load_page),
+                    buttonLabel = stringResource(R.string.retry)
+                )
             )
         }
     )

--- a/feature/shop/src/main/java/au/com/alfie/ecomm/feature/shop/ShopScreen.kt
+++ b/feature/shop/src/main/java/au/com/alfie/ecomm/feature/shop/ShopScreen.kt
@@ -24,7 +24,7 @@ import au.com.alfie.ecomm.core.navigation.arguments.wishlist.wishlistNavArgs
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
 import au.com.alfie.ecomm.core.ui.test.SERVICES_PAGE
 import au.com.alfie.ecomm.designsystem.component.bottombar.BottomBarState
-import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
+import au.com.alfie.ecomm.designsystem.component.dialog.error.ErrorType
 import au.com.alfie.ecomm.designsystem.component.segmented.SegmentedItem
 import au.com.alfie.ecomm.designsystem.component.segmented.SegmentedPage
 import au.com.alfie.ecomm.designsystem.component.snackbar.SnackbarCustomHostState
@@ -139,7 +139,7 @@ private fun ShopScreenContent(
                 onEvent = onWebViewEvent,
                 isBackHandlerEnabled = false,
                 modifier = Modifier.testTag(SERVICES_PAGE),
-                errorData = ErrorData(
+                errorType = ErrorType(
                     message = stringResource(R.string.error_failed_to_load_page),
                     buttonLabel = stringResource(R.string.retry)
                 )

--- a/feature/shop/src/main/res/values/strings.xml
+++ b/feature/shop/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="shop_error_cannot_load_brands_list">Cannot load Brands list</string>
     <string name="shop_error_unknown_error_occurred">Unknown error occurred</string>
     <string name="shop_search_brands">Search Brands</string>
+    <string name="retry">Retry</string>
+    <string name="error_failed_to_load_page">Failed to Load Page</string>
 </resources>

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
@@ -7,11 +7,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import au.com.alfie.ecomm.core.deeplink.DeeplinkHandler
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
+import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
 import au.com.alfie.ecomm.designsystem.component.dialog.ErrorScreen
-import au.com.alfie.ecomm.feature.R
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.Close
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.NavigateTo
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.OnHistoryUpdate
@@ -27,6 +26,7 @@ fun WebViewContent(
     headers: Map<String, String>,
     deeplinkHandler: DeeplinkHandler,
     onEvent: ClickEventOneArg<WebViewEvent>,
+    errorData: ErrorData,
     modifier: Modifier = Modifier,
     isBackHandlerEnabled: Boolean = true
 ) {
@@ -41,14 +41,10 @@ fun WebViewContent(
 
     Surface(modifier = modifier) {
         if (isLoadFailed) {
-            ErrorScreen(
-                message = stringResource(R.string.error_failed_to_load_page),
-                buttonLabel = stringResource(R.string.retry),
-                onClick = {
-                    isLoadFailed = false
-                    navigator.reload(content.url)
-                }
-            )
+            ErrorScreen(errorData.copy(onButtonClick = {
+                isLoadFailed = false
+                navigator.reload(content.url)
+            }))
         } else {
             WebView(
                 state = webViewState,

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
@@ -2,9 +2,16 @@ package au.com.alfie.ecomm.feature.webview
 
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import au.com.alfie.ecomm.core.deeplink.DeeplinkHandler
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
+import au.com.alfie.ecomm.designsystem.component.dialog.ErrorScreen
+import au.com.alfie.ecomm.feature.R
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.Close
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.NavigateTo
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.OnHistoryUpdate
@@ -30,15 +37,30 @@ fun WebViewContent(
     )
     val webViewState = rememberWebViewState(content)
     val navigator = rememberWebViewNavigator(deeplinkHandler)
+    var isLoadFailed by remember { mutableStateOf(false) }
 
     Surface(modifier = modifier) {
-        WebView(
-            state = webViewState,
-            onLoadingOverride = { onEvent(NavigateTo(it)) },
-            onHistoryUpdate = { onEvent(OnHistoryUpdate(it)) },
-            onClose = { onEvent(Close) },
-            navigator = navigator,
-            isBackHandlerEnabled = isBackHandlerEnabled
-        )
+        if (isLoadFailed) {
+            ErrorScreen(
+                message = stringResource(R.string.error_failed_to_load_page),
+                buttonLabel = stringResource(R.string.retry),
+                onClick = {
+                    isLoadFailed = false
+                    navigator.reload(content.url)
+                }
+            )
+        } else {
+            WebView(
+                state = webViewState,
+                onLoadingOverride = { onEvent(NavigateTo(it)) },
+                onHistoryUpdate = { onEvent(OnHistoryUpdate(it)) },
+                onClose = { onEvent(Close) },
+                navigator = navigator,
+                isBackHandlerEnabled = isBackHandlerEnabled,
+                onLoadFailure = {
+                    isLoadFailed = true
+                }
+            )
+        }
     }
 }

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewContent.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import au.com.alfie.ecomm.core.deeplink.DeeplinkHandler
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
-import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
-import au.com.alfie.ecomm.designsystem.component.dialog.ErrorScreen
+import au.com.alfie.ecomm.designsystem.component.dialog.error.ErrorScreen
+import au.com.alfie.ecomm.designsystem.component.dialog.error.ErrorType
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.Close
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.NavigateTo
 import au.com.alfie.ecomm.feature.webview.WebViewEvent.OnHistoryUpdate
@@ -26,7 +26,7 @@ fun WebViewContent(
     headers: Map<String, String>,
     deeplinkHandler: DeeplinkHandler,
     onEvent: ClickEventOneArg<WebViewEvent>,
-    errorData: ErrorData,
+    errorType: ErrorType,
     modifier: Modifier = Modifier,
     isBackHandlerEnabled: Boolean = true
 ) {
@@ -41,7 +41,7 @@ fun WebViewContent(
 
     Surface(modifier = modifier) {
         if (isLoadFailed) {
-            ErrorScreen(errorData.copy(onButtonClick = {
+            ErrorScreen(errorType.copy(onButtonClick = {
                 isLoadFailed = false
                 navigator.reload(content.url)
             }))

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebView.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebView.kt
@@ -12,15 +12,7 @@ import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -28,15 +20,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import au.com.alfie.ecomm.core.deeplink.DeeplinkResult
-import au.com.alfie.ecomm.designsystem.component.button.Button
-import au.com.alfie.ecomm.designsystem.component.button.ButtonType.Primary
 import au.com.alfie.ecomm.designsystem.component.loading.Loading
 import au.com.alfie.ecomm.designsystem.component.loading.LoadingType
-import au.com.alfie.ecomm.designsystem.theme.Theme
-import au.com.alfie.ecomm.feature.R
 import au.com.alfie.ecomm.feature.webview.component.WebContent.NavigatorOnly
 import au.com.alfie.ecomm.feature.webview.component.WebContent.Post
 import au.com.alfie.ecomm.feature.webview.component.WebContent.Url
@@ -50,6 +37,7 @@ internal fun WebView(
     onLoadingOverride: (DeeplinkResult) -> Unit,
     onHistoryUpdate: (HistoryUpdate) -> Unit,
     onClose: () -> Unit,
+    onLoadFailure: () -> Unit,
     modifier: Modifier = Modifier,
     client: WebViewClient = remember { WebViewClient() },
     chromeClient: WebChromeClient = remember { WebChromeClient() },
@@ -57,8 +45,6 @@ internal fun WebView(
 ) {
     BoxWithConstraints(modifier) {
         val isInitialLoading = remember { mutableStateOf(true) }
-        val isLoadFailed = remember { mutableStateOf(false) }
-
         val width = if (constraints.hasFixedWidth) MATCH_PARENT else WRAP_CONTENT
         val height = if (constraints.hasFixedHeight) MATCH_PARENT else WRAP_CONTENT
         val layoutParams = FrameLayout.LayoutParams(width, height)
@@ -112,84 +98,53 @@ internal fun WebView(
                 }
             }
         }
-        if (!isLoadFailed.value) {
-            AndroidView(
-                factory = { context ->
-                    WebView(context).apply {
-                        this.layoutParams = layoutParams
-                        this.isVerticalScrollBarEnabled = false
 
-                        state.viewState?.let {
-                            this.restoreState(it)
-                        }
+        AndroidView(
+            factory = { context ->
+                WebView(context).apply {
+                    this.layoutParams = layoutParams
+                    this.isVerticalScrollBarEnabled = false
 
-                        client.state = state
-                        client.navigator = navigator
-                        chromeClient.state = state
-
-                        webChromeClient = chromeClient
-                        webViewClient = object : android.webkit.WebViewClient() {
-                            override fun onReceivedError(
-                                view: WebView?,
-                                request: WebResourceRequest?,
-                                error: WebResourceError?
-                            ) {
-                                super.onReceivedError(view, request, error)
-                                isLoadFailed.value = true
-                            }
-
-                            override fun onReceivedHttpError(
-                                view: WebView?,
-                                request: WebResourceRequest?,
-                                errorResponse: WebResourceResponse?
-                            ) {
-                                super.onReceivedHttpError(view, request, errorResponse)
-                                isLoadFailed.value = true
-                            }
-                        }
-
-                        settings.setSupportZoom(false)
-                        settings.displayZoomControls = false
-                        settings.javaScriptEnabled = true
-                    }.also {
-                        state.webView = it
+                    state.viewState?.let {
+                        this.restoreState(it)
                     }
-                },
-                modifier = modifier
-            )
-        }
 
-        if (isLoadFailed.value) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = stringResource(R.string.error_failed_to_load_page),
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-                    Spacer(modifier = Modifier.height(Theme.spacing.spacing20))
-                    Button(
-                        type = Primary,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(PaddingValues(horizontal = Theme.spacing.spacing20)),
-                        onClick = {
-                            isLoadFailed.value = false
-                            state.webView?.reload()
-                        },
-                        isEnabled = true,
-                        text = stringResource(R.string.retry)
-                    )
+                    client.state = state
+                    client.navigator = navigator
+                    chromeClient.state = state
+
+                    webChromeClient = chromeClient
+                    webViewClient = object : android.webkit.WebViewClient() {
+                        override fun onReceivedError(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                            error: WebResourceError?
+                        ) {
+                            super.onReceivedError(view, request, error)
+                            onLoadFailure()
+                        }
+
+                        override fun onReceivedHttpError(
+                            view: WebView?,
+                            request: WebResourceRequest?,
+                            errorResponse: WebResourceResponse?
+                        ) {
+                            super.onReceivedHttpError(view, request, errorResponse)
+                            onLoadFailure()
+                        }
+                    }
+
+                    settings.setSupportZoom(false)
+                    settings.displayZoomControls = false
+                    settings.javaScriptEnabled = true
+                }.also {
+                    state.webView = it
                 }
-            }
-        }
+            },
+            modifier = modifier
+        )
         // Show loading dots while WebView is loading initial content
-        else if (isInitialLoading.value) {
+        if (isInitialLoading.value) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebView.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebView.kt
@@ -4,12 +4,23 @@ import android.annotation.SuppressLint
 import android.net.Uri
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -17,10 +28,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import au.com.alfie.ecomm.core.deeplink.DeeplinkResult
+import au.com.alfie.ecomm.designsystem.component.button.Button
+import au.com.alfie.ecomm.designsystem.component.button.ButtonType.Primary
 import au.com.alfie.ecomm.designsystem.component.loading.Loading
 import au.com.alfie.ecomm.designsystem.component.loading.LoadingType
+import au.com.alfie.ecomm.designsystem.theme.Theme
+import au.com.alfie.ecomm.feature.R
 import au.com.alfie.ecomm.feature.webview.component.WebContent.NavigatorOnly
 import au.com.alfie.ecomm.feature.webview.component.WebContent.Post
 import au.com.alfie.ecomm.feature.webview.component.WebContent.Url
@@ -41,6 +57,7 @@ internal fun WebView(
 ) {
     BoxWithConstraints(modifier) {
         val isInitialLoading = remember { mutableStateOf(true) }
+        val isLoadFailed = remember { mutableStateOf(false) }
 
         val width = if (constraints.hasFixedWidth) MATCH_PARENT else WRAP_CONTENT
         val height = if (constraints.hasFixedHeight) MATCH_PARENT else WRAP_CONTENT
@@ -95,36 +112,84 @@ internal fun WebView(
                 }
             }
         }
+        if (!isLoadFailed.value) {
+            AndroidView(
+                factory = { context ->
+                    WebView(context).apply {
+                        this.layoutParams = layoutParams
+                        this.isVerticalScrollBarEnabled = false
 
-        AndroidView(
-            factory = { context ->
-                WebView(context).apply {
-                    this.layoutParams = layoutParams
-                    this.isVerticalScrollBarEnabled = false
+                        state.viewState?.let {
+                            this.restoreState(it)
+                        }
 
-                    state.viewState?.let {
-                        this.restoreState(it)
+                        client.state = state
+                        client.navigator = navigator
+                        chromeClient.state = state
+
+                        webChromeClient = chromeClient
+                        webViewClient = object : android.webkit.WebViewClient() {
+                            override fun onReceivedError(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                                error: WebResourceError?
+                            ) {
+                                super.onReceivedError(view, request, error)
+                                isLoadFailed.value = true
+                            }
+
+                            override fun onReceivedHttpError(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                                errorResponse: WebResourceResponse?
+                            ) {
+                                super.onReceivedHttpError(view, request, errorResponse)
+                                isLoadFailed.value = true
+                            }
+                        }
+
+                        settings.setSupportZoom(false)
+                        settings.displayZoomControls = false
+                        settings.javaScriptEnabled = true
+                    }.also {
+                        state.webView = it
                     }
+                },
+                modifier = modifier
+            )
+        }
 
-                    client.state = state
-                    client.navigator = navigator
-                    chromeClient.state = state
-
-                    webChromeClient = chromeClient
-                    webViewClient = client
-
-                    settings.setSupportZoom(false)
-                    settings.displayZoomControls = false
-                    settings.javaScriptEnabled = true
-                }.also {
-                    state.webView = it
+        if (isLoadFailed.value) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = stringResource(R.string.error_failed_to_load_page),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Spacer(modifier = Modifier.height(Theme.spacing.spacing20))
+                    Button(
+                        type = Primary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(PaddingValues(horizontal = Theme.spacing.spacing20)),
+                        onClick = {
+                            isLoadFailed.value = false
+                            state.webView?.reload()
+                        },
+                        isEnabled = true,
+                        text = stringResource(R.string.retry)
+                    )
                 }
-            },
-            modifier = modifier
-        )
-
+            }
+        }
         // Show loading dots while WebView is loading initial content
-        if (isInitialLoading.value) {
+        else if (isInitialLoading.value) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebViewNavigator.kt
+++ b/feature/src/main/java/au/com/alfie/ecomm/feature/webview/component/WebViewNavigator.kt
@@ -81,4 +81,10 @@ internal class WebViewNavigator(
             navigationEvents.emit(event)
         }
     }
+
+    fun reload(url: String) {
+        coroutineScope.launch {
+            navigationEvents.emit(LoadUrl(url))
+        }
+    }
 }

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="retry">Retry</string>
+    <string name="error_failed_to_load_page">Failed to Load Page</string>
+</resources>

--- a/feature/webview/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewScreen.kt
@@ -15,7 +15,7 @@ import au.com.alfie.ecomm.core.navigation.arguments.wishlist.wishlistNavArgs
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
 import au.com.alfie.ecomm.core.ui.util.stringResource
 import au.com.alfie.ecomm.designsystem.component.bottombar.BottomBarState
-import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
+import au.com.alfie.ecomm.designsystem.component.dialog.error.ErrorType
 import au.com.alfie.ecomm.designsystem.component.searchbar.rememberSearchState
 import au.com.alfie.ecomm.designsystem.component.snackbar.SnackbarCustomHostState
 import au.com.alfie.ecomm.designsystem.component.topbar.TopBarState
@@ -93,7 +93,7 @@ private fun WebViewScreenContent(
             headers = state.content.headers,
             deeplinkHandler = deeplinkHandler,
             onEvent = onEvent,
-            errorData = ErrorData(
+            errorType = ErrorType(
                 message = androidx.compose.ui.res.stringResource(R.string.error_failed_to_load_page),
                 buttonLabel = androidx.compose.ui.res.stringResource(R.string.retry)
             )

--- a/feature/webview/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewScreen.kt
+++ b/feature/webview/src/main/java/au/com/alfie/ecomm/feature/webview/WebViewScreen.kt
@@ -15,10 +15,12 @@ import au.com.alfie.ecomm.core.navigation.arguments.wishlist.wishlistNavArgs
 import au.com.alfie.ecomm.core.ui.event.ClickEventOneArg
 import au.com.alfie.ecomm.core.ui.util.stringResource
 import au.com.alfie.ecomm.designsystem.component.bottombar.BottomBarState
+import au.com.alfie.ecomm.designsystem.component.dialog.ErrorData
 import au.com.alfie.ecomm.designsystem.component.searchbar.rememberSearchState
 import au.com.alfie.ecomm.designsystem.component.snackbar.SnackbarCustomHostState
 import au.com.alfie.ecomm.designsystem.component.topbar.TopBarState
 import au.com.alfie.ecomm.designsystem.component.topbar.action.TopBarAction
+import au.com.alfie.ecomm.feature.R
 import au.com.alfie.ecomm.feature.uievent.handleUIEvents
 import au.com.alfie.ecomm.feature.webview.model.WebViewUIState
 import com.ramcosta.composedestinations.annotation.Destination
@@ -90,7 +92,11 @@ private fun WebViewScreenContent(
             queryParameters = state.content.queryParameters,
             headers = state.content.headers,
             deeplinkHandler = deeplinkHandler,
-            onEvent = onEvent
+            onEvent = onEvent,
+            errorData = ErrorData(
+                message = androidx.compose.ui.res.stringResource(R.string.error_failed_to_load_page),
+                buttonLabel = androidx.compose.ui.res.stringResource(R.string.retry)
+            )
         )
 
         is WebViewUIState.Error -> WebViewError()


### PR DESCRIPTION
### Description

In services tab, when webpage cannot load, instead of showing webpage default error, now we are showing a proper message with a retry button similar to the iOS app.

### Screenshots
<img width="292" alt="image" src="https://github.com/user-attachments/assets/c956f04d-5d37-4dd8-aa94-e7850d5a2acf" />
