### PR TITLE
[ALFMOB-447] Modern Design Rollout — Startup / Splash screen

### DIFF
--- a/designsystem/src/main/java/com/mindera/alfie/designsystem/component/loading/LoadingSpinner.kt
+++ b/designsystem/src/main/java/com/mindera/alfie/designsystem/component/loading/LoadingSpinner.kt
@@ -1,0 +1,80 @@
+package com.mindera.alfie.designsystem.component.loading
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import com.mindera.alfie.designsystem.theme.Theme
+import com.mindera.alfie.designsystem.tokens.LocalTheme
+
+// Figma "Loading Spinner" (Design System, node 6619-47283): a thin rounded indeterminate arc.
+// The Small (24dp) reference has a ~2dp stroke (1dp inset each side), i.e. diameter / 12; the stroke
+// scales proportionally with the diameter across sizes.
+private const val STROKE_TO_DIAMETER_RATIO = 12f
+
+/**
+ * Design-system loading spinner — an indeterminate, rotating circular arc.
+ *
+ * Sizes follow the Figma spec (node 6619-47283): [LoadingSpinnerSize.Small] 24dp,
+ * [LoadingSpinnerSize.Medium] 32dp, [LoadingSpinnerSize.Large] 48dp. The arc colour defaults to
+ * `content/content-primary`; pass [color] to override (e.g. on a dark surface).
+ */
+@Composable
+fun LoadingSpinner(
+    modifier: Modifier = Modifier,
+    size: LoadingSpinnerSize = LoadingSpinnerSize.Small,
+    color: Color = LocalTheme.current.color.content.contentPrimary
+) {
+    val diameter = size.dimension()
+    CircularProgressIndicator(
+        modifier = modifier.size(diameter),
+        color = color,
+        strokeWidth = diameter / STROKE_TO_DIAMETER_RATIO,
+        trackColor = Color.Transparent,
+        strokeCap = StrokeCap.Round
+    )
+}
+
+enum class LoadingSpinnerSize {
+    Small,
+    Medium,
+    Large
+}
+
+@Composable
+private fun LoadingSpinnerSize.dimension(): Dp {
+    val spacing = LocalTheme.current.spacing
+    return when (this) {
+        LoadingSpinnerSize.Small -> spacing.spacing24 // 24dp
+        LoadingSpinnerSize.Medium -> spacing.spacing32 // 32dp
+        LoadingSpinnerSize.Large -> spacing.spacing48 // 48dp
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingSpinnerPreview() {
+    Theme {
+        LoadingSpinner(size = LoadingSpinnerSize.Small)
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingSpinnerMediumPreview() {
+    Theme {
+        LoadingSpinner(size = LoadingSpinnerSize.Medium)
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingSpinnerLargePreview() {
+    Theme {
+        LoadingSpinner(size = LoadingSpinnerSize.Large)
+    }
+}

--- a/designsystem/src/main/res/drawable/brand_logo.xml
+++ b/designsystem/src/main/res/drawable/brand_logo.xml
@@ -1,0 +1,42 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="160dp"
+    android:height="49dp"
+    android:viewportWidth="160"
+    android:viewportHeight="49">
+  <path
+      android:pathData="M18.91,25.08V11.87L14.72,21.16H11.06L6.87,11.87V25.08H0V0H7.5L12.89,11.8L18.31,0H25.78V25.08H18.91Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M30.08,25.08V0H36.94V25.08H30.08Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M48.11,12.75V25.08H41.24V0H46.59L56.63,12.75V0H63.5V25.08H58.04L48.11,12.75Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M67.8,25.08V0H77.41C85.72,0 90.02,5.58 90.02,12.5C90.02,20.1 85.02,25.08 77.41,25.08H67.8ZM77.41,6H74.66V19.07H77.41C81,19.07 83.05,16.28 83.05,12.5C83.05,8.62 80.93,6 77.41,6Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M110.87,19.07V25.08H93.05V0H110.55V6H99.92V9.54H109V15.12H99.92V19.07L110.87,19.07Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M114.07,25.08V0H125.56C130.45,0 133.97,4.41 133.97,8.69C133.97,11.58 132.63,14.27 130.38,15.86L136.02,25.08H128.27L123.51,17.38H120.94V25.08H114.07ZM120.94,11.37H125.27C126.12,11.37 127,10.38 127,8.69C127,6.96 125.94,6 125.1,6H120.94V11.37Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M135.8,25.08L145.14,0H150.7L160,25.08H152.74L151.23,20.17H144.57L143.1,25.08H135.8ZM147.92,7.17L145.6,15.58H150.14L147.92,7.17Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M92.61,49V38.3H99.05V39.45H93.9V43.06H98.72V44.21H93.9V47.85H99.13V49H92.61Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M90.02,38.3V49H88.72V38.3H90.02Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M80.11,49V38.3H86.51V39.45H81.4V43.06H86.03V44.21H81.4V49H80.11Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M71.86,49V38.3H73.15V47.85H78.11V49H71.86Z"
+      android:fillColor="#111111"/>
+  <path
+      android:pathData="M62.38,49H61.02L64.94,38.3H66.28L70.19,49H68.84L65.65,39.99H65.57L62.38,49ZM62.88,44.82H68.34V45.97H62.88V44.82Z"
+      android:fillColor="#111111"/>
+</vector>

--- a/feature/startup/src/main/java/com/mindera/alfie/feature/startup/StartUp.kt
+++ b/feature/startup/src/main/java/com/mindera/alfie/feature/startup/StartUp.kt
@@ -1,16 +1,24 @@
 package com.mindera.alfie.feature.startup
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mindera.alfie.core.navigation.Screen
-import com.mindera.alfie.designsystem.component.loading.LogoLoading
+import com.mindera.alfie.designsystem.R
+import com.mindera.alfie.designsystem.icons.AlfieIcons
+import com.mindera.alfie.designsystem.theme.Theme
 import com.mindera.alfie.designsystem.tokens.LocalTheme
 
 @Composable
@@ -19,18 +27,55 @@ fun StartUp(
 ) {
     val viewModel: StartUpViewModel = hiltViewModel()
     val startDestination by viewModel.startDestination.collectAsStateWithLifecycle()
-    val c = LocalTheme.current.primitive.colors
+    val theme = LocalTheme.current
 
     if (startDestination == null) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(c.neutrals0),
+                // D1: background = Figma surface/background-primary (#ffffff)
+                .background(theme.color.surface.backgroundPrimary),
+            // D6: content centred both axes
             contentAlignment = Alignment.Center
         ) {
-            LogoLoading()
+            SplashContent()
         }
     } else {
         appContent(startDestination ?: Screen.Home)
+    }
+}
+
+@Composable
+private fun SplashContent(
+    modifier: Modifier = Modifier
+) {
+    val theme = LocalTheme.current
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        // D5: wordmark -> spinner gap = Figma spacing/spacing-s (16)
+        verticalArrangement = Arrangement.spacedBy(theme.spacing.spacing16)
+    ) {
+        // D2: MINDERA / ALFIE wordmark (vector, intrinsic 160x49), colour tokenised via content-primary
+        Icon(
+            painter = painterResource(R.drawable.brand_logo),
+            contentDescription = null,
+            tint = theme.color.content.contentPrimary
+        )
+        // D3: static loading spinner (24dp) — D4: colour = content/content-primary (#111111)
+        Icon(
+            painter = painterResource(AlfieIcons.Loading),
+            contentDescription = null,
+            tint = theme.color.content.contentPrimary,
+            modifier = Modifier.size(theme.sizing.icon.medium)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SplashContentPreview() {
+    Theme {
+        SplashContent()
     }
 }

--- a/feature/startup/src/main/java/com/mindera/alfie/feature/startup/StartUp.kt
+++ b/feature/startup/src/main/java/com/mindera/alfie/feature/startup/StartUp.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,7 +16,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mindera.alfie.core.navigation.Screen
 import com.mindera.alfie.designsystem.R
-import com.mindera.alfie.designsystem.icons.AlfieIcons
+import com.mindera.alfie.designsystem.component.loading.LoadingSpinner
+import com.mindera.alfie.designsystem.component.loading.LoadingSpinnerSize
 import com.mindera.alfie.designsystem.theme.Theme
 import com.mindera.alfie.designsystem.tokens.LocalTheme
 
@@ -62,13 +62,8 @@ private fun SplashContent(
             contentDescription = null,
             tint = theme.color.content.contentPrimary
         )
-        // D3: static loading spinner (24dp) — D4: colour = content/content-primary (#111111)
-        Icon(
-            painter = painterResource(AlfieIcons.Loading),
-            contentDescription = null,
-            tint = theme.color.content.contentPrimary,
-            modifier = Modifier.size(theme.sizing.icon.medium)
-        )
+        // D3: design-system LoadingSpinner, Small (24dp) — D4: colour defaults to content/content-primary
+        LoadingSpinner(size = LoadingSpinnerSize.Small)
     }
 }
 


### PR DESCRIPTION
## Context
Child story of the [ALFMOB-428](https://mindera.atlassian.net/browse/ALFMOB-428) "Modern Design Rollout" epic — [ALFMOB-447](https://mindera.atlassian.net/browse/ALFMOB-447). Restyles the startup/splash screen (`feature/startup`) to the modern Figma design using `designsystem` components and `LocalTheme.current` tokens. **Visual-only** — no behaviour, navigation, data-layer, or BFF changes.

Figma source of truth: `Alfie — Designs (Mobile)`, "Loading" frame `node-id=2670-22814`.

## What changed
- **`StartUp.kt`** — splash/loading state rebuilt to match Figma: white background (`color.surface.backgroundPrimary`), a centred `Column` (16dp gap) with the **MINDERA / ALFIE wordmark** above a **loading spinner**. Stops rendering `LogoLoading()` (the animated cube GIF, which no longer matches the design). VM wiring, loaders, and navigation untouched.
- **`brand_logo.xml`** — new vector wordmark (160×49, `#111111`), rendered via `Icon` and tinted with `content.contentPrimary`.
- **New `LoadingSpinner` design-system component** (`designsystem/.../component/loading/LoadingSpinner.kt`) built from the Design-System Figma (`node-id=6619-47283`): wraps Jetpack Compose `CircularProgressIndicator` (indeterminate rotating arc), with `LoadingSpinnerSize` (Small 24 / Medium 32 / Large 48dp from spacing tokens) and a token-defaulted `color`. Splash uses `Small`.
- `@Preview`s added for the splash content and all three spinner sizes.

## Out of scope / deferred
- Dark mode.
- ⚠️ **Loader animation:** ALFMOB-447 lists loader animation as out of scope (static only). The new `LoadingSpinner` uses the indeterminate Compose indicator, so the splash spinner **now animates** — done at explicit request to use the Compose circular indicator. Flag at design sign-off if a static splash is required for this ticket.

## Testing
- ✅ `./gradlew :feature:startup:compileDebugKotlin`
- ✅ `./gradlew detekt` (0 code smells)
- ✅ `./gradlew :feature:startup:test` (no behaviour regression)
- Repo has no screenshot-test infra; the AC's "regenerate screenshot baselines" is N/A — Compose previews + visual compare against Figma are the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ALFMOB-428]: https://mindera.atlassian.net/browse/ALFMOB-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ALFMOB-447]: https://mindera.atlassian.net/browse/ALFMOB-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ